### PR TITLE
Chunked reading fix

### DIFF
--- a/config/hoge.conf
+++ b/config/hoge.conf
@@ -1,6 +1,6 @@
 server{
 	server_name "hoge_server";
-	listen 8081;
+	listen 8080;
 	client_max_body_size 1000000;
 # index index.html index.php index.htm;
 
@@ -16,7 +16,7 @@ server{
 
 server{
 	server_name "hoge_server";
-	listen 8080;
+	listen 9000;
 	client_max_body_size 1000000;
 # index index.html index.php index.htm;
 

--- a/srcs/HTTP/HTTPHead.cpp
+++ b/srcs/HTTP/HTTPHead.cpp
@@ -88,7 +88,6 @@ namespace ft {
                 const std::string versionComp = "HTTP/1.";
                 _HTTPv = _save.substr(0, i);
                 _save.erase(0, i + DELIM.size());
-                std::cerr << "CHANGING STATUS\n";
                 _parseStatus = headerFields;
                 if (_HTTPv.size() != HTTPV.size() || _HTTPv.compare(0, versionComp.size(), versionComp) != 0 || !isdigit(_HTTPv[_HTTPv.size() - 1])) {
                     _throw(505, "HTTP Version Not Supported");
@@ -125,7 +124,7 @@ namespace ft {
             }
         }
         // decide if header is complete (line break reached because \r\n is the first character)
-        if (_save.find(DELIM) == 0) {
+        if (_save.find(DELIM) == 0 || _save.find(BREAK) != std::string::npos) {
             _save.erase(0, DELIM.size()); 
             _parseStatus = complete;
         }

--- a/srcs/HTTP/HTTPHead.cpp
+++ b/srcs/HTTP/HTTPHead.cpp
@@ -98,7 +98,7 @@ namespace ft {
     }
 
     void    HTTPHead::parseHeaderFields() {
-        while (_save.find(DELIM) != 0 && _save.find(DELIM) != std::string::npos) {
+        while (_save.find(DELIM) != 0 && _save.find(DELIM) != std::string::npos && _save.find(CN) != std::string::npos) {
             // get header key
             if (_currentHeader.first == "") {
                 size_t i = _save.find(CN);
@@ -126,7 +126,6 @@ namespace ft {
         }
         // decide if header is complete (line break reached because \r\n is the first character)
         if (_save.find(DELIM) == 0) {
-
             _save.erase(0, DELIM.size()); 
             _parseStatus = complete;
         }

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -47,6 +47,9 @@ namespace ft
 
 		try
 		{
+			// remove all fds from closed fd vector
+			// socket_.check_keep_time_and_close_fd();
+
 			recieved_msg = socket_.recieve_msg();
 			//socket_.send_msg(recieved_msg.client_id, "HTTP/1.1 200 OK\nContent-Length: 11\nContent-Type: text/html\n\nHello World");
 			//if (cd)

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -1,4 +1,4 @@
-#include "server.hpp"
+t #include "server.hpp"
 
 namespace ft
 {

--- a/srcs/server/server.cpp
+++ b/srcs/server/server.cpp
@@ -1,4 +1,4 @@
-t #include "server.hpp"
+#include "server.hpp"
 
 namespace ft
 {

--- a/srcs/server/serverChild.cpp
+++ b/srcs/server/serverChild.cpp
@@ -247,8 +247,6 @@ namespace ft
 
     void	ServerChild::read_chunks_() {
 		// if read_bytes == 0, remove leading delim if it exists, and reset hex_bytes to 0
-		if (save_.empty())
-			std::cout << "YES>>> BUT WHY?\n";
 		if (hex_bytes_ && !read_bytes_) {
 			if (save_.find(DELIM) == 0) {
 				save_.erase(0, DELIM.size());
@@ -273,9 +271,6 @@ namespace ft
 				}
 				read_body_(save_.size());
 			} else { // if save_ is larger than remaining readbytes read remaining readbytes from save into body
-				/*body_ += save_.substr(0, read_bytes_);
-				save_.erase(0, read_bytes_);
-				read_bytes_ = 0;*/
 				read_body_(read_bytes_);
 				if (save_.find(DELIM) != 0) { // if delim is not first, there are unexpected body bytes
 		            throw_(400, "Bad Request - unexpected body bytes (chunked)");

--- a/srcs/server/serverChild.cpp
+++ b/srcs/server/serverChild.cpp
@@ -3,12 +3,14 @@
 namespace ft
 {
 
-	ServerChild::ServerChild(): server_config_(ServerConfig())
+	ServerChild::ServerChild(): server_config_(ServerConfig()), location_config_(), redirectList_map_(), response_code_(),
+		parse_status_(), HTTP_head_(), content_length_(), read_bytes_(), max_body_size_(), body_(), save_(), path_(), hex_bytes_()
 	{
 	}
 
 	ServerChild::ServerChild(const ServerConfig &server_config)
-		: server_config_(server_config)
+		: server_config_(server_config), location_config_(), redirectList_map_(), response_code_(),
+		parse_status_(), HTTP_head_(), content_length_(), read_bytes_(), max_body_size_(), body_(), save_(), path_(), hex_bytes_()
 	{
 		std::map<std::string, LocationConfig>::const_iterator itend = server_config.getLocationConfig().end();
 		for (std::map<std::string, LocationConfig>::const_iterator it = server_config.getLocationConfig().begin(); it != itend; ++it)
@@ -110,7 +112,7 @@ namespace ft
 	
 	void	ServerChild::Parse(const std::string& content) {
 		save_ += content;
-        if (parse_status_ == readChunks) {
+        if (parse_status_ == readChunks && !save_.empty()) {
             read_chunks_();
         } else if (parse_status_ == readStraight) {
             read_straight_();
@@ -221,15 +223,15 @@ namespace ft
         }
 	}
 
-	void	ServerChild::read_body_() {
- 	    read_bytes_ -= save_.size();
-    	body_ += save_;
-     	save_.clear();	
+	void	ServerChild::read_body_(unsigned int len) {
+ 	    read_bytes_ -= len;
+    	body_ += save_.substr(0, len);
+     	save_.erase(0, len);	
 	}
 
     void	ServerChild::read_straight_() {
 		if (read_bytes_ >= save_.size()) {
-			read_body_();
+			read_body_(save_.size());
 		} else {
             body_ += save_.substr(0, read_bytes_);
             save_.erase(0, read_bytes_);
@@ -244,36 +246,57 @@ namespace ft
 	}
 
     void	ServerChild::read_chunks_() {
-        while (save_.find(DELIM) != std::string::npos) {
-    		if (!read_bytes_) { 
-				get_hex_read_bytes_();
-		        if (read_bytes_ == 0) {	
-					response_code_ = 200;
-					parse_status_ = complete;
-					//HTTP_head_.GetHeaderFields()['transfer-encoding'] = "";
-					break ;
-				}
-				if (save_.find(DELIM) == std::string::npos) {
-					break ;
-				}
-				/* if never recieve 0?? */
-            }
-
-			if (read_bytes_ >= save_.size() - DELIM.size()) {
-				if (read_bytes_ == save_.size() - DELIM.size()) {
-					save_.erase(read_bytes_, DELIM.size());
-				}
-				read_body_();
-			} else {
-				body_ += save_.substr(0, read_bytes_);
-				save_.erase(0, read_bytes_);
-				read_bytes_ = 0;
-				if (save_.find(DELIM) != 0) {
-		            throw_(400, "Bad Request - unexpected body bytes (chunked)");
-				}
+		// if read_bytes == 0, remove leading delim if it exists, and reset hex_bytes to 0
+		if (save_.empty())
+			std::cout << "YES>>> BUT WHY?\n";
+		if (hex_bytes_ && !read_bytes_) {
+			if (save_.find(DELIM) == 0) {
 				save_.erase(0, DELIM.size());
 			}
+			hex_bytes_ = 0;
+			if (save_.empty())
+				return;
+		}	
+		// get hex bytes if == 0
+		if (!hex_bytes_){
+			get_hex_read_bytes_();
+			hex_bytes_ = read_bytes_;
+		}
+        while (hex_bytes_ && !save_.empty()) {
+			// if save_ is smaller/equal to readbytes, read all bytes from save into body 
+			if (read_bytes_ >= save_.size() - DELIM.size()) {
+				if (read_bytes_ == save_.size() - DELIM.size()) { // if save includes delim (not for reading), remove it
+					if (save_.substr(read_bytes_) != DELIM) { // if last bytes not == delim, chunk is larger than hex
+						throw_(400, "Bad Request - unexpected body bytes DELIM doesn't match");
+					}
+					save_.erase(read_bytes_, DELIM.size());
+				}
+				read_body_(save_.size());
+			} else { // if save_ is larger than remaining readbytes read remaining readbytes from save into body
+				/*body_ += save_.substr(0, read_bytes_);
+				save_.erase(0, read_bytes_);
+				read_bytes_ = 0;*/
+				read_body_(read_bytes_);
+				if (save_.find(DELIM) != 0) { // if delim is not first, there are unexpected body bytes
+		            throw_(400, "Bad Request - unexpected body bytes (chunked)");
+				}
+				save_.erase(0, DELIM.size()); // remove delim
+			}
+			// if no save left or no delim, return. must retrive more string for reading, or next hex
+			if (save_.empty() || (save_.find(DELIM) == std::string::npos)) {
+				break;
+			}
+			// get next hex 
+			if (read_bytes_ == 0) {
+				get_hex_read_bytes_();
+				hex_bytes_ = read_bytes_;
+			}
         }
+	    if (hex_bytes_ == 0) {	
+			response_code_ = 200;
+			parse_status_ = complete;
+			//HTTP_head_.GetHeaderFields()['transfer-encoding'] = "";
+		}
 	}
 
 	void	ServerChild::get_hex_read_bytes_() {

--- a/srcs/server/serverChild.hpp
+++ b/srcs/server/serverChild.hpp
@@ -55,6 +55,7 @@ namespace ft
 		std::string		body_;
 		std::string		save_;
 		std::string		path_;
+		unsigned int	hex_bytes_;
 
     	unsigned int	strBase_to_UI_(const std::string& str, std::ios_base& (*base)(std::ios_base&));
 		void    throw_(int responseCode, const std::string& message);
@@ -62,7 +63,7 @@ namespace ft
 		void	check_headers_();
 		void	check_method_();
 		void	decide_parse_status_();
-		void	read_body_();
+		void	read_body_(unsigned int len);
         void	read_straight_();
         void	read_chunks_();
 		void	get_hex_read_bytes_();

--- a/srcs/server/socket.cpp
+++ b/srcs/server/socket.cpp
@@ -82,8 +82,7 @@ namespace ft
 	}
 
 	Socket::RecievedMsg Socket::recieve_msg()
-	{
-		check_keep_time_and_close_fd();
+	{	
 		std::cout << "poll_fd_vec_.size(): " << poll_fd_vec_.size() << std::endl;
 		std::cout << "poll" << std::endl;
 		poll(&poll_fd_vec_[0], poll_fd_vec_.size(), 1000);
@@ -174,6 +173,7 @@ namespace ft
 				}
 			}
 		}
+		// return closed fds vector
 	}
 
 	void Socket::register_new_client_(int sock_fd)


### PR DESCRIPTION
chunked body reading - /r/nの読むを修正
header parsing  - headerが間違えるとき（例えばセミコロンがないヘッダー）blockingをし始まりましたと思います。そこに修正しました